### PR TITLE
Kamera Fehler Behebungen

### DIFF
--- a/crates/entities_lib/src/camera/logic.rs
+++ b/crates/entities_lib/src/camera/logic.rs
@@ -103,7 +103,7 @@ fn rotation_mouse(
         body_set,
         player_position + Vec3::Y * 0.5,
         Vec3::NEG_Y,
-        1.5,
+        1.75,
         true,
         QueryFilter::default().exclude_collider(player_entity),
     ) {
@@ -111,7 +111,7 @@ fn rotation_mouse(
     }
 
     // Ensure the camera doesn't go too close to the player.
-    if target_distance <= camera.zoom.min + 0.2 && final_translation.y < player_position.y {
+    if target_distance <= camera.zoom.min + 0.1 && final_translation.y < player_position.y - 0.4 {
         let test_rotation = Quat::from_euler(EulerRot::YXZ, yaw, pitch + 0.02, 0.0);
         let test_translation = player_position + test_rotation.mul_vec3(Vec3::new(0.0, 0.0, -target_distance));
 
@@ -120,7 +120,7 @@ fn rotation_mouse(
             body_set,
             test_translation,
             (player_position - test_translation).normalize(),
-            (player_position - test_translation).length(),
+            (player_position - test_translation).length() - 1.5,
             true,
             QueryFilter::default().exclude_collider(player_entity),
         ).is_none() {
@@ -130,7 +130,7 @@ fn rotation_mouse(
 
     // Adjust vertical camera position if too close to the player.
     let distance_to_player = (final_translation - player_position).length();
-    if distance_to_player < camera.zoom.offset_swap && final_translation.y > player_position.y {
+    if distance_to_player < camera.zoom.offset_swap && final_translation.y > player_position.y - 0.4 {
         final_translation.y += 0.6;
     }
 
@@ -140,7 +140,7 @@ fn rotation_mouse(
         body_set,
         player_position,
         (final_translation - player_position).normalize(),
-        target_distance + 1.0,
+        target_distance + 2.25,
         true,
         QueryFilter::default().exclude_collider(player_entity),
     ) {

--- a/crates/entities_lib/src/camera/logic.rs
+++ b/crates/entities_lib/src/camera/logic.rs
@@ -135,16 +135,25 @@ fn rotation_mouse(
     }
 
     // Final collision check to ensure camera doesn't pass through walls.
-    if let Some((_hit_entity, _)) = rapier_context.cast_ray(
+    if let Some((_hit_entity, hit)) = rapier_context.cast_ray_and_get_normal(
         colliders,
         body_set,
-        player_position,
+        player_position, // Cast from player position
         (final_translation - player_position).normalize(),
-        target_distance + 2.25,
+        target_distance + 2.25, // Check within max distance
         true,
         QueryFilter::default().exclude_collider(player_entity),
     ) {
-        final_translation = player_position + (final_translation - player_position).normalize() * (target_distance - 0.1);
+        // Directly set the final translation to the hit point, avoiding hanging at edges
+        final_translation = hit.point;
+
+        // Keep a minimum offset to prevent the camera from clipping into walls
+        final_translation += hit.normal * 0.15;
+
+        // Ensure the camera does not go under the ground
+        if final_translation.y < player_position.y - 0.4 {
+            final_translation.y = player_position.y - 0.4;
+        }
     }
 
     // Set final camera position.

--- a/crates/entities_lib/src/camera/logic.rs
+++ b/crates/entities_lib/src/camera/logic.rs
@@ -17,8 +17,8 @@ pub struct CameraLogicPlugin;
 impl Plugin for CameraLogicPlugin {
     fn build(&self, app: &mut App) {
         // Add systems for camera rotation, zoom, and cursor toggle, with conditions based on cursor lock state.
-        app.add_systems(PreUpdate, rotation_mouse.run_if(cursor_lock_condition));
-        app.add_systems(Update, zoom_mouse.run_if(cursor_lock_condition));
+        app.add_systems(PreUpdate, camera_core_logic.run_if(cursor_lock_condition));
+        app.add_systems(Update, zoom_mouse.run_if(cursor_lock_condition).after(camera_core_logic));
         app.add_systems(Update, toggle_cursor);
     }
 }
@@ -31,7 +31,7 @@ impl Plugin for CameraLogicPlugin {
 /// - `player_query`: Query to access the player entity and transform for position reference.
 /// - `rapier_query`: Query to access the physics context to detect obstacles for camera collision detection.
 /// - `mouse_events`: EventReader for mouse motion events to determine mouse movement.
-fn rotation_mouse(
+fn camera_core_logic(
     window_query: Query<&Window, With<PrimaryWindow>>,
     mut camera_query: Query<(&CameraController, &mut Transform), With<CameraController>>,
     player_query: Query<(Entity, &Transform), (With<WorldPlayer>, Without<CameraController>)>,

--- a/crates/entities_lib/src/camera/logic.rs
+++ b/crates/entities_lib/src/camera/logic.rs
@@ -87,7 +87,7 @@ fn camera_core_logic(
         body_set,
         player_position,
         (final_translation - player_position).normalize(),
-        camera.zoom.max,
+        0.1,
         true,
         QueryFilter::default().exclude_collider(player_entity),
     ) {
@@ -103,35 +103,17 @@ fn camera_core_logic(
         body_set,
         player_position + Vec3::Y * 0.5,
         Vec3::NEG_Y,
-        1.75,
+        0.0,
         true,
         QueryFilter::default().exclude_collider(player_entity),
     ) {
         final_translation.y = final_translation.y.max(floor_hit.point.y + 0.35);
     }
 
-    // Ensure the camera doesn't go too close to the player.
-    if target_distance <= camera.zoom.min + 0.1 && final_translation.y < player_position.y - 0.4 {
-        let test_rotation = Quat::from_euler(EulerRot::YXZ, yaw, pitch + 0.02, 0.0);
-        let test_translation = player_position + test_rotation.mul_vec3(Vec3::new(0.0, 0.0, -target_distance));
-
-        if rapier_context.cast_ray(
-            colliders,
-            body_set,
-            test_translation,
-            (player_position - test_translation).normalize(),
-            (player_position - test_translation).length() - 1.5,
-            true,
-            QueryFilter::default().exclude_collider(player_entity),
-        ).is_none() {
-            camera_transform.rotation = test_rotation;
-        }
-    }
-
     // Adjust vertical camera position if too close to the player.
     let distance_to_player = (final_translation - player_position).length();
-    if distance_to_player < camera.zoom.offset_swap && final_translation.y > player_position.y - 0.4 {
-        final_translation.y += 0.6;
+    if distance_to_player < camera.zoom.offset_swap && final_translation.y > player_position.y - 0.8 {
+        final_translation.y += camera.to_head;
     }
 
     // Final collision check to ensure camera doesn't pass through walls.
@@ -140,7 +122,7 @@ fn camera_core_logic(
         body_set,
         player_position, // Cast from player position
         (final_translation - player_position).normalize(),
-        target_distance + 1.5, // Check within max distance
+        target_distance + 0.1, // Check within max distance
         true,
         QueryFilter::default().exclude_collider(player_entity),
     ) {
@@ -156,9 +138,14 @@ fn camera_core_logic(
         }
     }
 
+    // Apply a small delay on movement with a fraction of interpolation
+    let interpolation_factor = camera.smoother; // Small factor for smooth movement
+    camera_transform.translation = camera_transform.translation.lerp(final_translation, interpolation_factor);
+
     // Set final camera position.
-    camera_transform.translation = final_translation;
+    camera_transform.translation = camera_transform.translation;
 }
+
 
 /// System to handle zoom functionality based on mouse scroll input.
 ///

--- a/crates/entities_lib/src/camera/logic.rs
+++ b/crates/entities_lib/src/camera/logic.rs
@@ -140,7 +140,7 @@ fn rotation_mouse(
         body_set,
         player_position, // Cast from player position
         (final_translation - player_position).normalize(),
-        target_distance + 2.25, // Check within max distance
+        target_distance + 1.5, // Check within max distance
         true,
         QueryFilter::default().exclude_collider(player_entity),
     ) {

--- a/crates/entities_lib/src/camera/mod.rs
+++ b/crates/entities_lib/src/camera/mod.rs
@@ -24,17 +24,21 @@ pub struct CameraController {
     pub lock_active: bool,    // Indicates whether the camera is locked to the player's viewpoint.
     pub zoom: Zoom,           // Holds zoom-related parameters (min, max zoom, etc.).
     pub offset: Offset,       // Offset that modifies the camera's position relative to the player.
+    pub to_head: f32,
     pub target_range: f32,    // Detection range for enemies (higher means far detection).
+    pub smoother: f32,
 }
 
 impl Default for CameraController {
     fn default() -> Self {
         Self {
-            sensitivity: Vec2::new(0.55, 0.55), // Default sensitivity values for the camera.
+            sensitivity: Vec2::new(0.45, 0.45), // Default sensitivity values for the camera.
             lock_active: true, // Camera is locked to the player by default.
             zoom: Zoom::new(1.0, 6.0), // Set the default zoom range (min: 1.0, max: 6.0).
             offset: Offset::new(0.0, 0.8), // Set default offset values for camera positioning.
+            to_head: 0.6,
             target_range: 7.5,
+            smoother: 0.7,
         }
     }
 }

--- a/crates/entities_lib/src/enemies/test_enemy.rs
+++ b/crates/entities_lib/src/enemies/test_enemy.rs
@@ -37,7 +37,7 @@ fn setup_enemy(mut commands: Commands, asset_server: Res<AssetServer>) {
         ),
         Name::new("Enemy-Test"),
         AnimatedMob,
-        Transform::from_xyz(-32.0, 50.0, 15.0),
+        Transform::from_xyz(-32.0, 15.0, 15.0),
         AiSetup {
             state: AiState::Idle,
             path: vec![


### PR DESCRIPTION
Momentan hat die Kamera folgende Fehler:

- Bewegt sich durch manche Wände
- Hängt sich am Spieler auf so das sie sich nur schwer befreien lässt
- Tele-portiert sich vom Spieler weg wenn sie zu Nahe kommt 